### PR TITLE
[DEV-1400] Hack followit to get it following AskbotUsers.

### DIFF
--- a/followit/__init__.py
+++ b/followit/__init__.py
@@ -120,7 +120,7 @@ def register(model):
     just "s" is added
     """
     from followit import models as followit_models
-    #from django.db import models as django_models
+    from django.db import models as django_models
     try:
         from django.contrib.auth import get_user_model
     except ImportError: # django < 1.5

--- a/followit/tests/runtests.py
+++ b/followit/tests/runtests.py
@@ -1,6 +1,7 @@
 import os, sys
 os.environ['DJANGO_SETTINGS_MODULE'] = 'followit.tests.settings'
-from django.test.simple import run_tests
-failures = run_tests(['tests.FollowerTests',], verbosity = 1)
+from django.test.simple import DjangoTestSuiteRunner
+test_runner = DjangoTestSuiteRunner(verbosity=1)
+failures = test_runner.run_tests(['tests.FollowerTests',])
 if failures:
     sys.exit(failures)

--- a/followit/tests/settings.py
+++ b/followit/tests/settings.py
@@ -1,8 +1,13 @@
 import os
 
 DIRNAME = os.path.dirname(__file__)
-DATABASE_ENGINE = 'django.db.backends.sqlite3'
-DATABASE_NAME = os.path.join(DIRNAME, 'database.db')
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(DIRNAME, 'database.db'),
+    }
+}
 
 INSTALLED_APPS = (
     'django.contrib.auth',
@@ -11,4 +16,4 @@ INSTALLED_APPS = (
     'followit.tests'
 )
 
-SECRET_KEY='supersekrit'
+SECRET_KEY = 'supersekrit'

--- a/followit/tests/settings.py
+++ b/followit/tests/settings.py
@@ -10,3 +10,5 @@ INSTALLED_APPS = (
     'followit',
     'followit.tests'
 )
+
+SECRET_KEY='supersekrit'

--- a/followit/tests/settings.py
+++ b/followit/tests/settings.py
@@ -1,7 +1,7 @@
 import os
 
 DIRNAME = os.path.dirname(__file__)
-DATABASE_ENGINE = 'sqlite3'
+DATABASE_ENGINE = 'django.db.backends.sqlite3'
 DATABASE_NAME = os.path.join(DIRNAME, 'database.db')
 
 INSTALLED_APPS = (


### PR DESCRIPTION
This is a super-hacky edit of followit to get it following AskbotUser objects without having to change any Askbot code.

The issue was that followit patches methods onto User that are dynamically named, but then Askbot refers to hard-coded versions of the same names.  When followit is told to follow User, it adds methods called "get_followed_users," "follow_user," and "unfollow_user" to auth User.  If it's given AskbotUser instead, then the methods are called "get_followed_askbotusers"... etc, and Askbot expects the methods to be named the old way.

Ideally, followit would be removed completely in favor of a ManyToManyField on AskbotUser, possibly with a 'through' model.  But for some reason, removing followit was causing problems. Even when followit isn't listed in INSTALLED_APPS, askbot loads it directly from the environment.  When it's not in INSTALLED_APPS, but in the environment, then trying to delete an AskbotUser raises a DatabaseError.  If it's not in INSTALLED_APPS AND not in the environment, then trying to CREATE an AskbotUser raises a DatabaseError.  Uuuugggllyyyyy.

This issue was blocking DEV-1411 (backfilling AskbotUsers for existing Users) because `AskbotUser.objects.get_or_create` was misbehaving.
